### PR TITLE
Feat: Pluto deprecation

### DIFF
--- a/invoice_receipt.hbs
+++ b/invoice_receipt.hbs
@@ -1,14 +1,6 @@
 <div>
     Your payment of {{{ amount }}} {{{ currency }}} was successful. You can manage your subscription <a
         href="http://{{{ account.domain }}}">here</a>.
-    <br /><br />
-    {{#if gasFee}}
-    Gas fee: {{{ gasFee }}} Gwei
-    {{/if}}
-    <br />
+    <br /><br /><br />
     Your license key: {{{ license }}}
-    <br />
-    {{#if transaction}}
-    Your transaction hash: <a href="https://etherscan.io/tx/{{{ transaction }}}">{{{ transaction }}}</a>
-    {{/if}}
 </div>


### PR DESCRIPTION
As I have removed our Pluto integration from Hyper, there's no longer a need be checking for gas fees or TX, so I've gone ahead and removed it from the invoice receipt template. 